### PR TITLE
[fix] .zshrc 色を使用可能 +@

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -70,6 +70,7 @@ NeoBundle 'itchyny/lightline.vim'
 NeoBundle 'Shougo/neocomplete.vim'
 NeoBundle 'Shougo/neosnippet'
 NeoBundle 'Shougo/neosnippet-snippets'
+NeoBundle 'airblade/vim-gitgutter'
 
 call neobundle#end()
 

--- a/.vimrc
+++ b/.vimrc
@@ -38,6 +38,9 @@ inoremap{<Enter> {}<LEFT><CR><ESC><S-o>
 inoremap[<Enter> []<LEFT><CR><ESC><S-o>
 inoremap(<Enter> ()<LEFT><CR><ESC><S-o>
 
+nnoremap <Space>h ^
+nnoremap <Space>l $
+
 :source $VIMRUNTIME/macros/matchit.vim
 
 " Note: Skip initialization for vim-tiny or vim-small.

--- a/.vimrc
+++ b/.vimrc
@@ -32,6 +32,7 @@ set laststatus=2
 
 set nocompatible
 set backspace=indent,eol,start
+set scrolloff=10
 
 inoremap{<Enter> {}<LEFT><CR><ESC><S-o>
 inoremap[<Enter> []<LEFT><CR><ESC><S-o>

--- a/.vimrc
+++ b/.vimrc
@@ -75,6 +75,7 @@ NeoBundle 'Shougo/neocomplete.vim'
 NeoBundle 'Shougo/neosnippet'
 NeoBundle 'Shougo/neosnippet-snippets'
 NeoBundle 'airblade/vim-gitgutter'
+NeoBundle 'bronson/vim-trailing-whitespace'
 
 call neobundle#end()
 

--- a/.zshrc
+++ b/.zshrc
@@ -1,10 +1,14 @@
 export PATH=$HOME/.nodebrew/current/bin:$PATH
 
+# 色を使用
+autoload -Uz colors
+colors
+
 # 補完機能を有効にする
 autoload -Uz compinit
 compinit
 
-# command
+# エイリアス
 alias l1='ls -1'
 alias la1='ls -a -1'
 alias de='cd ~/Desktop'


### PR DESCRIPTION
### 概要

* .zshrc 色の使用可能に変更
* エイリアスのコメントアウトを日本語に
* vim-gitgutterを追加
* スクロール位置を設定
* vim-trailing-whitespaceを追加
