### PR TITLE
[add] .vimrc surround.vimを追加 +@

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -46,6 +46,8 @@ inoremap{<Enter> {}<LEFT><CR><ESC><S-o>
 inoremap[<Enter> []<LEFT><CR><ESC><S-o>
 inoremap(<Enter> ()<LEFT><CR><ESC><S-o>
 
+inoremap <silent> jj <ESC>
+
 nnoremap <Space>h ^
 nnoremap <Space>l $
 

--- a/.vimrc
+++ b/.vimrc
@@ -50,6 +50,8 @@ inoremap{<Enter> {}<LEFT><CR><ESC><S-o>
 inoremap[<Enter> []<LEFT><CR><ESC><S-o>
 inoremap(<Enter> ()<LEFT><CR><ESC><S-o>
 
+inoremap<Space>e <CR><ESC><S-o>
+
 inoremap <silent> jj <ESC>
 
 nnoremap <Space>h ^

--- a/.vimrc
+++ b/.vimrc
@@ -21,7 +21,7 @@ set background=dark
 " let g:molokai_original=1
 
 " one_dark
-autocmd ColorScheme * highlight Visual ctermfg=233 ctermbg=3
+autocmd ColorScheme * highlight Visual ctermfg=233 ctermbg=11
 autocmd ColorScheme * highlight LineNr ctermfg=180
 colorscheme onedark
 let g:onedark_original=1

--- a/.vimrc
+++ b/.vimrc
@@ -77,6 +77,7 @@ NeoBundle 'Shougo/neosnippet-snippets'
 NeoBundle 'airblade/vim-gitgutter'
 NeoBundle 'bronson/vim-trailing-whitespace'
 NeoBundle 'surround.vim'
+NeoBundle 'tomtom/tcomment_vim'
 
 call neobundle#end()
 

--- a/.vimrc
+++ b/.vimrc
@@ -76,6 +76,7 @@ NeoBundle 'Shougo/neosnippet'
 NeoBundle 'Shougo/neosnippet-snippets'
 NeoBundle 'airblade/vim-gitgutter'
 NeoBundle 'bronson/vim-trailing-whitespace'
+NeoBundle 'surround.vim'
 
 call neobundle#end()
 

--- a/.vimrc
+++ b/.vimrc
@@ -12,11 +12,19 @@ set number
 set wildmenu
 set showcmd
 
-autocmd ColorScheme * highlight Visual ctermfg=233 ctermbg=118
-colorscheme molokai
 set t_Co=256
-let g:molokai_original=1
 set background=dark
+
+" molokai
+" autocmd ColorScheme * highlight Visual ctermfg=233 ctermbg=118
+" colorscheme molokai
+" let g:molokai_original=1
+
+" one_dark
+autocmd ColorScheme * highlight Visual ctermfg=233 ctermbg=3
+autocmd ColorScheme * highlight LineNr ctermfg=180
+colorscheme onedark
+let g:onedark_original=1
 
 set expandtab
 set tabstop=2

--- a/.vimrc
+++ b/.vimrc
@@ -42,6 +42,10 @@ set nocompatible
 set backspace=indent,eol,start
 set scrolloff=10
 
+set encoding=utf-8
+set fileencoding=utf-8
+set fileformats=unix,dos,mac
+
 inoremap{<Enter> {}<LEFT><CR><ESC><S-o>
 inoremap[<Enter> []<LEFT><CR><ESC><S-o>
 inoremap(<Enter> ()<LEFT><CR><ESC><S-o>


### PR DESCRIPTION
### 概要

* .vimrc surround.vimを追加
* .vimrc tcommentを追加
* .vimrc onedarkを追加
* .vimrc キーマップ インサートモードをjjで抜ける
* .vimrc 文字コード変更
* .vimrc  キーマップを追加