### PR TITLE
[vimrc] 差し替え

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -56,7 +56,7 @@ colorscheme wombat256mod
 " autocmd ColorScheme * highlight Comment term=bold ctermfg=246 gui=italic guifg=#9c998e
 " colorscheme 1989
 
-
+autocmd BufNewFile,BufRead *.{html,htm,vue*} set filetype=html
 
 " タブ,インデント設定
 set expandtab
@@ -134,22 +134,31 @@ NeoBundleFetch 'Shougo/neobundle.vim'
 " Note: You don't set neobundle setting in .gvimrc!
 
 " プラグイン
+" highlight
 NeoBundle 'mattn/emmet-vim'
 NeoBundle 'hail2u/vim-css3-syntax'
 NeoBundle 'othree/html5.vim'
 NeoBundle 'pangloss/vim-javascript'
+NeoBundle 'cakebaker/scss-syntax.vim'
+NeoBundle 'jwalton512/vim-blade'
+NeoBundle 'othree/yajs.vim'
+NeoBundle 'maxmellon/vim-jsx-pretty'
+
+" develop
 NeoBundle 'itchyny/lightline.vim'
 NeoBundle 'Shougo/neocomplete.vim'
 NeoBundle 'Shougo/neosnippet'
 NeoBundle 'Shougo/neosnippet-snippets'
+
+" github
 NeoBundle 'airblade/vim-gitgutter'
+NeoBundle 'tpope/vim-fugitive'
+
+" other
 NeoBundle 'bronson/vim-trailing-whitespace'
 NeoBundle 'surround.vim'
 NeoBundle 'tomtom/tcomment_vim'
-NeoBundle 'tpope/vim-fugitive'
 NeoBundle 'scrooloose/nerdtree'
-NeoBundle 'cakebaker/scss-syntax.vim'
-NeoBundle 'jwalton512/vim-blade'
 NeoBundle 'rking/ag.vim'
 NeoBundle 'ctrlpvim/ctrlp.vim'
 NeoBundle 'editorconfig/editorconfig-vim'

--- a/.vimrc
+++ b/.vimrc
@@ -39,14 +39,24 @@ set background=dark
 " wombat
 autocmd ColorScheme * highlight Directory ctermfg=113
 autocmd ColorScheme * highlight Statement ctermfg=110
+autocmd ColorScheme * highlight LineNr ctermbg=none
+autocmd ColorScheme * highlight Normal ctermbg=none
+autocmd ColorScheme * highlight NonText ctermbg=none
+autocmd ColorScheme * highlight SpecialKey ctermbg=none
+autocmd ColorScheme * highlight EndOfBuffer ctermbg=none
 colorscheme wombat256mod
 
 " 1989
 " autocmd ColorScheme * highlight Normal ctermbg=none
 " autocmd ColorScheme * highlight LineNr ctermbg=none
 " autocmd ColorScheme * highlight Visual ctermbg=102
+" autocmd ColorScheme * highlight ExtraWhitespace ctermbg=225 guibg=#ffdfff
+" autocmd ColorScheme * highlight Search cterm=none ctermfg=236 ctermbg=225 guifg=#303030 guibg=#ffdfff
 " autocmd ColorScheme * highlight NonText ctermbg=none ctermfg=102
+" autocmd ColorScheme * highlight Comment term=bold ctermfg=246 gui=italic guifg=#9c998e
 " colorscheme 1989
+
+
 
 " タブ,インデント設定
 set expandtab
@@ -144,7 +154,12 @@ NeoBundle 'rking/ag.vim'
 NeoBundle 'ctrlpvim/ctrlp.vim'
 NeoBundle 'editorconfig/editorconfig-vim'
 NeoBundle 'open-browser.vim'
-NeoBundle 'scrooloose/syntastic.git'
+NeoBundle 'neomake/neomake'
+NeoBundle 'benjie/neomake-local-eslint.vim'
+NeoBundle 'basyura/TweetVim'
+NeoBundle 'basyura/twibill.vim'
+NeoBundle 'nathanaelkane/vim-indent-guides'
+NeoBundle 'mileszs/ack.vim'
 
 call neobundle#end()
 
@@ -397,12 +412,35 @@ vmap gx <Plug>(openbrowser-smart-search)
 
 
 """""""""""""""""""""""""""""""""""""""""""""""
-" Syntasticの設定
+" Neomakeの設定
 """""""""""""""""""""""""""""""""""""""""""""""
-set statusline+=%#warningmsg#
-set statusline+=%{SyntasticStatuslineFlag()}
-set statusline+=%*
+autocmd! BufWritePost * Neomake
 
-let g:syntastic_check_on_open = 1
-let g:syntastic_check_on_wq = 0
-let g:syntastic_scss_checkers = ['scss-syntax.vim']
+let g:neomake_javascript_enabled_makers = ['eslint']
+let g:neomake_css_enabled_maker = ['stylelint']
+let g:neomake_error_sign = {'text' : '>>', 'texthl' : 'Error'}
+let g:neomake_warning_sign = {'text' : '>>', 'texthl' : 'ToDo'}
+
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""
+" TweetVimの設定
+"""""""""""""""""""""""""""""""""""""""""""""""
+let g:tweetvim_tweet_per_page = 50
+
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""
+" vim-indent-guidesの設定
+"""""""""""""""""""""""""""""""""""""""""""""""
+let g:indent_guides_enable_on_vim_startup = 1
+let g:indent_guides_auto_colors = 0
+autocmd VimEnter,Colorscheme * :hi IndentGuidesOdd  ctermbg=239
+autocmd VimEnter,Colorscheme * :hi IndentGuidesEven ctermbg=238
+
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""
+" ack.vimの設定
+"""""""""""""""""""""""""""""""""""""""""""""""
+let g:ackprg = 'ag --nogroup --nocolor --column'


### PR DESCRIPTION
## 概要

プラグイン追加等

#### メモ

神速C5, 6, 7が火力、範囲共に優秀で
武将にも当てやすいので神速チャージ始動→追撃が理想。

レイスとグリフィン、スーパーアーマー持ちには、
無理して神速Cを当てに行くと被弾率が少し上がるので、
通常神術→C3のループが安定。余裕がある時のみ神速C始動。

分身時の神速が強力で雑魚殲滅は快適。対モンス性能、ハメ性能も高め。
神速と横槍の少ないC3しか使わないので、立ち回りをミスらなければ被弾率も低め。

斬神速ゲーで見ても面白くないと思うけど、念のため動画
いつかの早川殿の動画を参考にしてる。分身武将とカオスは大体スルー。

属性の神速が謎の8だし、2回目だからタイムを縮めようと思えば縮められるけど、
タイムアタック要素が強くなるのでとりあえず。
ここではS-が妥当としとくけど、意見があれば欲しい。